### PR TITLE
SDK-1456 - [Android Docs] Update documentation installation from jitpack to maven central

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -150,4 +150,4 @@ After adding the dependency:
 
 Your Android project is now configured to use the Paydock Mobile SDK. You can proceed to [initialize the SDK](/setup/initialise.md) and start implementing payment functionality in your application.
 
-**Note:** The SDK requires Android API level 21 (Android 5.0) or higher.
+**Note:** The SDK requires Android API level 24 (Android 7.0) or higher.


### PR DESCRIPTION
…ack to maven central

- Updated Android installation section to use Maven Central configuration rather than Jitpack